### PR TITLE
feat: Add lhapdf6, gzip, and mg5mes support to PYTHIA8 build 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About pythia8-feedstock
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/pythia8-feedstock/blob/main/LICENSE.txt)
 
-Home: https://pythia.org/
+Home: http://home.thep.lu.se/Pythia/
 
 Package license: GPL-2.0-only
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,12 +7,6 @@ else
     PYTHIA_ARCH=DARWIN
 fi
 
-if [ "${ARCH}" == "64" ]; then
-    EXTRAS="--enable-64bit"
-else
-    EXTRAS=""
-fi
-
 # Use pybind11 from conda-forge
 sed -i 's@overload_caster_t@override_caster_t@g' plugins/python/src/*.cpp
 rm -rf plugins/python/include/pybind11
@@ -30,10 +24,8 @@ fi
 ./configure \
     --with-python-include="$(python -c "from sysconfig import get_paths; info = get_paths(); print(info['include'])")" \
     --with-python-bin="${PREFIX}/bin/" \
-    --arch=${PYTHIA_ARCH} \
-    --enable-shared \
-    --prefix=${PREFIX} \
-    ${EXTRAS}
+    --arch="${PYTHIA_ARCH}" \
+    --prefix="${PREFIX}"
 
 make install -j${CPU_COUNT}
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -25,7 +25,11 @@ fi
     --with-python-include="$(python -c "from sysconfig import get_paths; info = get_paths(); print(info['include'])")" \
     --with-python-bin="${PREFIX}/bin/" \
     --arch="${PYTHIA_ARCH}" \
-    --prefix="${PREFIX}"
+    --prefix="${PREFIX}" \
+    --with-lhapdf6-bin="${PREFIX}/bin/" \
+    --with-lhapdf6-include="${PREFIX}/include/" \
+    --with-gzip-include="${PREFIX}/include/" \
+    --with-mg5mes
 
 make install -j${CPU_COUNT}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 90c811abe7a3d2ffdbf9b4aeab51cf6e0a5a8befb4e3efa806f3d5b9c311e227
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=root

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,8 @@ requirements:
     - python
     - libxcrypt  # [linux and py<39]
     - pybind11
+    - lhapdf >=6.2
+    - zlib >=1.0.0
   run:
     - python
 


### PR DESCRIPTION
Resolves #37

Requires PR #38 to go in first and then should be rebased.

* The options `--enable-shared` and `--enable-64bit` are not supported in PYTHIA 8.310, so they are removed. c.f. https://gitlab.com/Pythia8/releases/-/blob/b5a3fb48f79b3b4441cbf22f7ab710be3b1d7a46/configure
* Bump the build number.
* Add `lhapdf` and `zlip` to host requirements.
* Enable `--with-lhadpdf6`, `--with-gzip`, and `--with-mg5mes` configure options for the PYTHIA8 build.
* MNT: Re-rendered with conda-build 24.7.1, conda-smithy 3.38.0, and conda-forge-pinning 2024.08.13.15.51.23

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
