### PR TITLE
fix: Add zlib as run requirement

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - patches/0001-fix-cfg_file-setting-in-configure-8.311.patch
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win]
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=root
@@ -39,11 +39,12 @@ requirements:
     - zlib
   run:
     - python
+    # zlib needed to be compatible with cxx-compiler
+    - zlib
 
 test:
   requires:
     - lhapdf >=6.2
-    - zlib
     - make
     - cxx-compiler
   imports:

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -85,8 +85,14 @@ fi
 unset _with_mg5mes
 
 #
-echo -e "\n# Test example main51 that uses LHAPDF library extension"
+echo -e "\n# Test example main01"
 cd examples/
+make clean
+
+"$CXX" main01.cc -o main01 $(pythia8-config --cxxflags --ldflags)
+./main01 &> main01_output.txt
+
+echo -e "\n# Test example main51 that uses LHAPDF library extension"
 make clean
 # avoid lots of output to stdout from download of the file
 lhapdf install NNPDF31_nnlo_as_0118_luxqed &> /dev/null
@@ -101,4 +107,4 @@ else
 fi
 
 "$CXX" main51.cc -o main51 $(pythia8-config --cxxflags --ldflags)
-./main51
+./main51 &> main51_output.txt


### PR DESCRIPTION
* While `zlib` isn't formally required for things to run if there is already a C++ compiler on the target machine (as it should already be installed through requiring `python` as a `run` requirement), if `cxx-compiler` is installed in the same environment (which is a common pattern for C++ projects) compilation will fail with

```
<Pythia8 prefix directory>/include/Pythia8/Streams.h:23:10: fatal error: zlib.h: No such file or directory
```

To guard against this, include `zlib` as a `run` requirement, which, while possibly redundant, should make things easier for the end user and should not impose any requirement conflicts either.
* Remove `zlib` as an additional test environment requirement.
* Add `main01` example to tests as the simplest check of `zlib`.
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
