### PR TITLE
ENH: Distribute share/Pythia8/examples/Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -38,11 +38,14 @@ make install --jobs="${CPU_COUNT}"
 make clean
 
 # Remove documentation and examples from share/Pythia8 as not needed for runtime.
-# Keep share/Pythia8/examples/Makefile.inc as that might be looked for.
+# Keep share/Pythia8/examples/Makefile.inc and share/Pythia8/examples/Makefile as
+# they might be looked for.
 # Keep share/Pythia8/xmldoc as required at runtime.
 mv $PREFIX/share/Pythia8/examples/Makefile.inc .
+mv $PREFIX/share/Pythia8/examples/Makefile .
 rm -rf $PREFIX/share/Pythia8/examples/*
 mv Makefile.inc $PREFIX/share/Pythia8/examples/Makefile.inc
+mv Makefile $PREFIX/share/Pythia8/examples/Makefile
 rm -rf $PREFIX/share/Pythia8/htmldoc
 rm -rf $PREFIX/share/Pythia8/pdfdoc
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "pythia8" %}
 {% set file_version = "8312" %}
 {% set version = file_version[0] + "." + file_version[1:] %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
* This is needed as `MadGraph5_aMC@NLO`'s `MG5aMC_PY8_interface` checks for `share/Pythia8/examples/Makefile` at compile time.
   - c.f. https://github.com/mg5amcnlo/MG5aMC_PY8_interface/blob/5d82df1b77bd2b69ffeae5b6bfe100a62b31c30e/compile.py#L127
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
