### PR TITLE
ENH: Add HepMC2 and HepMC3 support

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -31,6 +31,8 @@ fi
     --prefix="${PREFIX}" \
     --with-lhapdf6="${PREFIX}" \
     --with-fastjet3="${PREFIX}" \
+    --with-hepmc2="${PREFIX}" \
+    --with-hepmc3="${PREFIX}" \
     --with-gzip="${PREFIX}" \
     --with-mg5mes
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "pythia8" %}
 {% set file_version = "8312" %}
 {% set version = file_version[0] + "." + file_version[1:] %}
-{% set build = 2 %}
+{% set build = 3 %}
 
 package:
   name: {{ name|lower }}
@@ -41,6 +41,8 @@ requirements:
     - pybind11
     - lhapdf
     - fastjet-cxx
+    - hepmc2
+    - hepmc3
     # zlib controlled through https://github.com/conda-forge/conda-forge-pinning-feedstock/
     - zlib
   run:
@@ -53,6 +55,8 @@ test:
     - {{ compiler('cxx') }}
     - lhapdf >=6.2
     - fastjet-cxx
+    - hepmc2
+    - hepmc3
     - make
     - sed
   imports:
@@ -60,11 +64,22 @@ test:
   source_files:
     - examples/Makefile
     - examples/main101.cc
+    - examples/main131.cc
+    - examples/main132.cc
+    - examples/main132.cmnd
+    - examples/main133.cc
+    - examples/main133.cmnd
+    - examples/main134.cc
+    - examples/main134.cmnd
+    - examples/main135.cc
     - examples/main161.cc
+    - examples/main161.cmnd
     - examples/main201.cc
     - examples/main212.cc
-    - examples/main161.cmnd
     - examples/w+_production_lhc_0.lhe
+    - examples/ttbar.lhe
+    - examples/ttbar2.lhe
+    - examples/wbj_lhef3.lhe
 
 about:
   home: https://pythia.org/

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -111,55 +111,57 @@ make clean
 "$CXX" main101.cc -o main101 $(pythia8-config --cxxflags --ldflags)
 ./main101 &> main101_output.txt || ./main101
 
+# Exit early under emulation
 if [[ "${build_platform}" != "${target_platform}" ]]; then
     echo -e "\n# Target platform ${target_platform} requires emulation on"\
         "${build_platform} runners and will be too slow to run the full tests,"\
         "and so is being skipped."
-else
-    echo -e "\n# Test example main161 that uses the FastJet library extension"
-    make clean
-    # avoid lots of output to stdout from download of the file
-    lhapdf install cteq6l1 &> /dev/null
-
-    "$CXX" main161.cc -o main161 $CXXFLAGS $LDFLAGS -lpythia8 -lfastjet
-    ./main161 main161.cmnd w+_production_lhc_0.lhe histout161.dat &> main161_output.txt || ./main161 main161.cmnd w+_production_lhc_0.lhe histout161.dat
-
-    echo -e "\n# Test example main201 that uses the LHAPDF library extension"
-    make clean
-    # avoid lots of output to stdout from download of the file
-    lhapdf install NNPDF31_nnlo_as_0118_luxqed &> /dev/null
-
-    # The examples assume you built locally and didn't install, so need to patch
-    # the relative path (../share) to the absolute path ($PREFIX/share)
-    sed -i "s|../share|$(readlink -f $PREFIX/share)|g" main201.cc
-
-    "$CXX" main201.cc -o main201 $(pythia8-config --cxxflags --ldflags)
-    ./main201 &> main201_output.txt || ./main201
-
-    echo -e "\n# Test example main212 that uses the FastJet library extension"
-    make clean
-
-    "$CXX" main212.cc -o main212 $CXXFLAGS $LDFLAGS -lpythia8 -lfastjet
-    ./main212 &> main212_output.txt || ./main212
-
-    echo -e "\n# Test example that use the HepMC2 and HepMC3 extensions"
-    "$CXX" main131.cc -o main131 $CXXFLAGS $LDFLAGS -lpythia8 -lHepMC3
-    ./main131 &> main131_output.txt || ./main131
-    test -f main131.hepmc
-
-    "$CXX" main132.cc -o main132 $CXXFLAGS $LDFLAGS -lpythia8 -lHepMC3
-    ./main132 main132.cmnd main132.hepmc &> main132_output.txt || ./main132 main132.cmnd main132.hepmc
-    test -f main132.hepmc
-
-    "$CXX" main133.cc -o main133 $CXXFLAGS $LDFLAGS -lpythia8 -lHepMC3
-    ./main133 main133.cmnd main133.hepmc &> main133_output.txt || ./main133 main133.cmnd main133.hepmc
-    test -f main133.hepmc
-
-    "$CXX" main134.cc -o main134 $CXXFLAGS $LDFLAGS -lpythia8 -lHepMC3
-    ./main134 main134.cmnd main134.hepmc &> main134_output.txt || ./main134 main134.cmnd main134.hepmc
-    test -f main134.hepmc
-
-    "$CXX" main135.cc -o main135 $CXXFLAGS $LDFLAGS -lpythia8 -lHepMC3
-    ./main135 &> main135_output.txt || ./main135
-    test -f main135.hepmc
+    exit 0
 fi
+
+echo -e "\n# Test example main161 that uses the FastJet library extension"
+make clean
+# avoid lots of output to stdout from download of the file
+lhapdf install cteq6l1 &> /dev/null
+
+"$CXX" main161.cc -o main161 $CXXFLAGS $LDFLAGS -lpythia8 -lfastjet
+./main161 main161.cmnd w+_production_lhc_0.lhe histout161.dat &> main161_output.txt || ./main161 main161.cmnd w+_production_lhc_0.lhe histout161.dat
+
+echo -e "\n# Test example main201 that uses the LHAPDF library extension"
+make clean
+# avoid lots of output to stdout from download of the file
+lhapdf install NNPDF31_nnlo_as_0118_luxqed &> /dev/null
+
+# The examples assume you built locally and didn't install, so need to patch
+# the relative path (../share) to the absolute path ($PREFIX/share)
+sed -i "s|../share|$(readlink -f $PREFIX/share)|g" main201.cc
+
+"$CXX" main201.cc -o main201 $(pythia8-config --cxxflags --ldflags)
+./main201 &> main201_output.txt || ./main201
+
+echo -e "\n# Test example main212 that uses the FastJet library extension"
+make clean
+
+"$CXX" main212.cc -o main212 $CXXFLAGS $LDFLAGS -lpythia8 -lfastjet
+./main212 &> main212_output.txt || ./main212
+
+echo -e "\n# Test example that use the HepMC2 and HepMC3 extensions"
+"$CXX" main131.cc -o main131 $CXXFLAGS $LDFLAGS -lpythia8 -lHepMC3
+./main131 &> main131_output.txt || ./main131
+test -f main131.hepmc
+
+"$CXX" main132.cc -o main132 $CXXFLAGS $LDFLAGS -lpythia8 -lHepMC3
+./main132 main132.cmnd main132.hepmc &> main132_output.txt || ./main132 main132.cmnd main132.hepmc
+test -f main132.hepmc
+
+"$CXX" main133.cc -o main133 $CXXFLAGS $LDFLAGS -lpythia8 -lHepMC3
+./main133 main133.cmnd main133.hepmc &> main133_output.txt || ./main133 main133.cmnd main133.hepmc
+test -f main133.hepmc
+
+"$CXX" main134.cc -o main134 $CXXFLAGS $LDFLAGS -lpythia8 -lHepMC3
+./main134 main134.cmnd main134.hepmc &> main134_output.txt || ./main134 main134.cmnd main134.hepmc
+test -f main134.hepmc
+
+"$CXX" main135.cc -o main135 $CXXFLAGS $LDFLAGS -lpythia8 -lHepMC3
+./main135 &> main135_output.txt || ./main135
+test -f main135.hepmc

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -132,7 +132,7 @@ cd examples/
 make clean
 
 "$CXX" main101.cc -o main101 $(pythia8-config --cxxflags --ldflags)
-./main101 &> main101_output.txt
+./main101 &> main101_output.txt || ./main101
 
 echo -e "\n# Test example main161 that uses the FastJet library extension"
 make clean
@@ -140,7 +140,7 @@ make clean
 lhapdf install cteq6l1 &> /dev/null
 
 "$CXX" main161.cc -o main161 $CXXFLAGS $LDFLAGS -lpythia8 -lfastjet
-./main161 main161.cmnd w+_production_lhc_0.lhe histout161.dat &> main161_output.txt
+./main161 main161.cmnd w+_production_lhc_0.lhe histout161.dat &> main161_output.txt || ./main161 main161.cmnd w+_production_lhc_0.lhe histout161.dat
 
 echo -e "\n# Test example main201 that uses the LHAPDF library extension"
 make clean
@@ -152,13 +152,13 @@ lhapdf install NNPDF31_nnlo_as_0118_luxqed &> /dev/null
 sed -i "s|../share|$(readlink -f $PREFIX/share)|g" main201.cc
 
 "$CXX" main201.cc -o main201 $(pythia8-config --cxxflags --ldflags)
-./main201 &> main201_output.txt
+./main201 &> main201_output.txt || ./main201
 
 echo -e "\n# Test example main212 that uses the FastJet library extension"
 make clean
 
 "$CXX" main212.cc -o main212 $CXXFLAGS $LDFLAGS -lpythia8 -lfastjet
-./main212 &> main212_output.txt
+./main212 &> main212_output.txt || ./main212
 
 echo -e "\n# Test example that use the HepMC2 and HepMC3 extensions"
 "$CXX" main131.cc -o main131 $CXXFLAGS $LDFLAGS -lpythia8 -lHepMC3

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -134,49 +134,55 @@ make clean
 "$CXX" main101.cc -o main101 $(pythia8-config --cxxflags --ldflags)
 ./main101 &> main101_output.txt || ./main101
 
-echo -e "\n# Test example main161 that uses the FastJet library extension"
-make clean
-# avoid lots of output to stdout from download of the file
-lhapdf install cteq6l1 &> /dev/null
+if [[ "${build_platform}" != "${target_platform}" ]]; then
+    echo -e "\n# Target platform ${target_platform} requires emulation on"\
+        "${build_platform} runners and will be too slow to run the full tests,"\
+        "and so is being skipped."
+else
+    echo -e "\n# Test example main161 that uses the FastJet library extension"
+    make clean
+    # avoid lots of output to stdout from download of the file
+    lhapdf install cteq6l1 &> /dev/null
 
-"$CXX" main161.cc -o main161 $CXXFLAGS $LDFLAGS -lpythia8 -lfastjet
-./main161 main161.cmnd w+_production_lhc_0.lhe histout161.dat &> main161_output.txt || ./main161 main161.cmnd w+_production_lhc_0.lhe histout161.dat
+    "$CXX" main161.cc -o main161 $CXXFLAGS $LDFLAGS -lpythia8 -lfastjet
+    ./main161 main161.cmnd w+_production_lhc_0.lhe histout161.dat &> main161_output.txt || ./main161 main161.cmnd w+_production_lhc_0.lhe histout161.dat
 
-echo -e "\n# Test example main201 that uses the LHAPDF library extension"
-make clean
-# avoid lots of output to stdout from download of the file
-lhapdf install NNPDF31_nnlo_as_0118_luxqed &> /dev/null
+    echo -e "\n# Test example main201 that uses the LHAPDF library extension"
+    make clean
+    # avoid lots of output to stdout from download of the file
+    lhapdf install NNPDF31_nnlo_as_0118_luxqed &> /dev/null
 
-# The examples assume you built locally and didn't install, so need to patch
-# the relative path (../share) to the absolute path ($PREFIX/share)
-sed -i "s|../share|$(readlink -f $PREFIX/share)|g" main201.cc
+    # The examples assume you built locally and didn't install, so need to patch
+    # the relative path (../share) to the absolute path ($PREFIX/share)
+    sed -i "s|../share|$(readlink -f $PREFIX/share)|g" main201.cc
 
-"$CXX" main201.cc -o main201 $(pythia8-config --cxxflags --ldflags)
-./main201 &> main201_output.txt || ./main201
+    "$CXX" main201.cc -o main201 $(pythia8-config --cxxflags --ldflags)
+    ./main201 &> main201_output.txt || ./main201
 
-echo -e "\n# Test example main212 that uses the FastJet library extension"
-make clean
+    echo -e "\n# Test example main212 that uses the FastJet library extension"
+    make clean
 
-"$CXX" main212.cc -o main212 $CXXFLAGS $LDFLAGS -lpythia8 -lfastjet
-./main212 &> main212_output.txt || ./main212
+    "$CXX" main212.cc -o main212 $CXXFLAGS $LDFLAGS -lpythia8 -lfastjet
+    ./main212 &> main212_output.txt || ./main212
 
-echo -e "\n# Test example that use the HepMC2 and HepMC3 extensions"
-"$CXX" main131.cc -o main131 $CXXFLAGS $LDFLAGS -lpythia8 -lHepMC3
-./main131 &> main131_output.txt || ./main131
-test -f main131.hepmc
+    echo -e "\n# Test example that use the HepMC2 and HepMC3 extensions"
+    "$CXX" main131.cc -o main131 $CXXFLAGS $LDFLAGS -lpythia8 -lHepMC3
+    ./main131 &> main131_output.txt || ./main131
+    test -f main131.hepmc
 
-"$CXX" main132.cc -o main132 $CXXFLAGS $LDFLAGS -lpythia8 -lHepMC3
-./main132 main132.cmnd main132.hepmc &> main132_output.txt || ./main132 main132.cmnd main132.hepmc
-test -f main132.hepmc
+    "$CXX" main132.cc -o main132 $CXXFLAGS $LDFLAGS -lpythia8 -lHepMC3
+    ./main132 main132.cmnd main132.hepmc &> main132_output.txt || ./main132 main132.cmnd main132.hepmc
+    test -f main132.hepmc
 
-"$CXX" main133.cc -o main133 $CXXFLAGS $LDFLAGS -lpythia8 -lHepMC3
-./main133 main133.cmnd main133.hepmc &> main133_output.txt || ./main133 main133.cmnd main133.hepmc
-test -f main133.hepmc
+    "$CXX" main133.cc -o main133 $CXXFLAGS $LDFLAGS -lpythia8 -lHepMC3
+    ./main133 main133.cmnd main133.hepmc &> main133_output.txt || ./main133 main133.cmnd main133.hepmc
+    test -f main133.hepmc
 
-"$CXX" main134.cc -o main134 $CXXFLAGS $LDFLAGS -lpythia8 -lHepMC3
-./main134 main134.cmnd main134.hepmc &> main134_output.txt || ./main134 main134.cmnd main134.hepmc
-test -f main134.hepmc
+    "$CXX" main134.cc -o main134 $CXXFLAGS $LDFLAGS -lpythia8 -lHepMC3
+    ./main134 main134.cmnd main134.hepmc &> main134_output.txt || ./main134 main134.cmnd main134.hepmc
+    test -f main134.hepmc
 
-"$CXX" main135.cc -o main135 $CXXFLAGS $LDFLAGS -lpythia8 -lHepMC3
-./main135 &> main135_output.txt || ./main135
-test -f main135.hepmc
+    "$CXX" main135.cc -o main135 $CXXFLAGS $LDFLAGS -lpythia8 -lHepMC3
+    ./main135 &> main135_output.txt || ./main135
+    test -f main135.hepmc
+fi

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 #
 echo -e "\n# Check installed directory structure"
 echo "# test -d ${PREFIX}/bin"
@@ -39,8 +41,11 @@ else
 fi
 echo "# test -f ${PREFIX}/lib/libpythia8lhapdf6.so"
 test -f "${PREFIX}/lib/libpythia8lhapdf6.so"
+test -f "${PREFIX}/share/Pythia8/examples/Makefile"
 echo "# test -f ${PREFIX}/share/Pythia8/examples/Makefile.inc"
 test -f "${PREFIX}/share/Pythia8/examples/Makefile.inc"
+
+cat ${PREFIX}/share/Pythia8/examples/Makefile.inc
 
 #
 echo -e "\n# Check pythia8-config CLI API and flags return expected values"
@@ -70,6 +75,26 @@ else
     exit 1
 fi
 unset _with_fastjet3
+
+echo ""
+_with_hepmc2=$(pythia8-config --with-hepmc2)
+if [[ "${_with_hepmc2}" == "true" ]]; then
+    echo -e "# pythia8-config --with-hepmc2: ${_with_hepmc2}"
+else
+    echo "pythia8-config --with-hepmc2 is ${_with_hepmc2} but should be true"
+    exit 1
+fi
+unset _with_hepmc2
+
+echo ""
+_with_hepmc3=$(pythia8-config --with-hepmc3)
+if [[ "${_with_hepmc3}" == "true" ]]; then
+    echo -e "# pythia8-config --with-hepmc3: ${_with_hepmc3}"
+else
+    echo "pythia8-config --with-hepmc3 is ${_with_hepmc3} but should be true"
+    exit 1
+fi
+unset _with_hepmc3
 
 echo ""
 _with_gzip=$(pythia8-config --with-gzip)
@@ -134,3 +159,24 @@ make clean
 
 "$CXX" main212.cc -o main212 $CXXFLAGS $LDFLAGS -lpythia8 -lfastjet
 ./main212 &> main212_output.txt
+
+echo -e "\n# Test example that use the HepMC2 and HepMC3 extensions"
+"$CXX" main131.cc -o main131 $CXXFLAGS $LDFLAGS -lpythia8 -lHepMC3
+./main131 &> main131_output.txt || ./main131
+test -f main131.hepmc
+
+"$CXX" main132.cc -o main132 $CXXFLAGS $LDFLAGS -lpythia8 -lHepMC3
+./main132 main132.cmnd main132.hepmc &> main132_output.txt || ./main132 main132.cmnd main132.hepmc
+test -f main132.hepmc
+
+"$CXX" main133.cc -o main133 $CXXFLAGS $LDFLAGS -lpythia8 -lHepMC3
+./main133 main133.cmnd main133.hepmc &> main133_output.txt || ./main133 main133.cmnd main133.hepmc
+test -f main133.hepmc
+
+"$CXX" main134.cc -o main134 $CXXFLAGS $LDFLAGS -lpythia8 -lHepMC3
+./main134 main134.cmnd main134.hepmc &> main134_output.txt || ./main134 main134.cmnd main134.hepmc
+test -f main134.hepmc
+
+"$CXX" main135.cc -o main135 $CXXFLAGS $LDFLAGS -lpythia8 -lHepMC3
+./main135 &> main135_output.txt || ./main135
+test -f main135.hepmc

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -2,59 +2,36 @@
 
 set -x
 
-#
 echo -e "\n# Check installed directory structure"
-echo "# test -d ${PREFIX}/bin"
 test -d "${PREFIX}/bin"
-echo "# test -d ${PREFIX}/include"
 test -d "${PREFIX}/include"
-echo "# test -d ${PREFIX}/include/Pythia8"
 test -d "${PREFIX}/include/Pythia8"
-echo "# test -d ${PREFIX}/lib"
 test -d "${PREFIX}/lib"
-echo "# test -d ${PREFIX}/share"
 test -d "${PREFIX}/share"
-echo "# test -d ${PREFIX}/share/Pythia8"
 test -d "${PREFIX}/share/Pythia8"
-echo "# test -d ${PREFIX}/share/Pythia8/examples"
 test -d "${PREFIX}/share/Pythia8/examples"
-echo "# test -d ${PREFIX}/share/Pythia8/xmldoc"
 test -d "${PREFIX}/share/Pythia8/xmldoc"
 
-echo "# test ! -d ${PREFIX}/share/Pythia8/htmldoc"
 test ! -d "${PREFIX}/share/Pythia8/htmldoc"
-echo "# test ! -d ${PREFIX}/share/Pythia8/pdfdoc"
 test ! -d "${PREFIX}/share/Pythia8/pdfdoc"
 
 echo -e "\n# Check installed files"
-echo "# test -f ${PREFIX}/bin/pythia8-config"
 test -f "${PREFIX}/bin/pythia8-config"
-echo "# test -f ${PREFIX}/include/Pythia8/Pythia.h"
 test -f "${PREFIX}/include/Pythia8/Pythia.h"
-if [[ "${target_platform}" == linux-* ]]; then
-    echo "# test -f ${PREFIX}/lib/libpythia8.so"
-    test -f "${PREFIX}/lib/libpythia8.so"
-else
-    # macOS
-    echo "# test -f ${PREFIX}/lib/libpythia8.dylib"
-    test -f "${PREFIX}/lib/libpythia8.dylib"
-fi
-echo "# test -f ${PREFIX}/lib/libpythia8lhapdf6.so"
+test -f "${PREFIX}/lib/libpythia8${SHLIB_EXT}"
 test -f "${PREFIX}/lib/libpythia8lhapdf6.so"
 test -f "${PREFIX}/share/Pythia8/examples/Makefile"
-echo "# test -f ${PREFIX}/share/Pythia8/examples/Makefile.inc"
 test -f "${PREFIX}/share/Pythia8/examples/Makefile.inc"
 
 cat ${PREFIX}/share/Pythia8/examples/Makefile.inc
 
 #
 echo -e "\n# Check pythia8-config CLI API and flags return expected values"
-echo -e "# pythia8-config --help\n"
 pythia8-config --help
 
-echo -e "\n# pythia8-config --cxxflags: $(pythia8-config --cxxflags)"
+pythia8-config --cxxflags
 
-echo -e "\n# pythia8-config --ldflags: $(pythia8-config --ldflags)"
+pythia8-config --ldflags
 
 echo ""
 _with_lhapdf6=$(pythia8-config --with-lhapdf6)


### PR DESCRIPTION
* Add hepmc2 and hepmc3 as 'host' and 'test' requirements.
* Add '--with-hepmc2' and '--with-hepmc3' to build.
* Add checks for valid '--with-hepmc2' and '--with-hepmc3'.
* Add tests for HepMC3 use.
* Run the full tests only when not under emulation to reduce build time.
* Bump build number.

Related to https://github.com/conda-forge/mg5amcnlo-feedstock/issues/2

This will be backported to a `8.311` branch so that `mg5amnclo` can use it (`mg5amncnlo` `v3.5.7` supports only Pythia `8.311` and HepMC2).

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
