### PR TITLE
FIX: Ensure BUILD_PREFIX removed from Makefile.inc

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -39,6 +39,9 @@ fi
 make install --jobs="${CPU_COUNT}"
 make clean
 
+# Patch out $BUILD_PREFIX from the path for CXX
+sed -i "s|$BUILD_PREFIX|$PREFIX|g" $PREFIX/share/Pythia8/examples/Makefile.inc
+
 # Remove documentation and examples from share/Pythia8 as not needed for runtime.
 # Keep share/Pythia8/examples/Makefile.inc and share/Pythia8/examples/Makefile as
 # they might be looked for.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "pythia8" %}
 {% set file_version = "8312" %}
 {% set version = file_version[0] + "." + file_version[1:] %}
-{% set build = 3 %}
+{% set build = 4 %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
* As other programs can used PREFIX/share/Pythia8/examples/Makefile and PREFIX/share/Pythia8/examples/Makefile.inc, the values of them need to be patched by conda-build to have valid PREFIX paths. By default a BUILD_PREFIX shows for CXX in the Makefile.inc

```
CXX=$BUILD_PREFIX/bin/$(basename $CXX)
```

so the BUILD_PREFIX needs to get patched with PREFIX.
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
